### PR TITLE
feat: implement GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ permissions:
 
 jobs:
   publish_python:
-
     name: Publish Python
     runs-on: ubuntu-latest
     environment:
@@ -27,16 +26,16 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,29 @@
+name: Version
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  semver:
+    # Add this condition to skip recursive releases
+    if: "!contains(github.event.head_commit.message, 'Release:')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    name: Update Version
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Print Environment Variables
+      run: |
+        env
+    - name: Run TinySemVer
+      uses: ./  # This uses the action defined in the current repository
+      with:
+        verbose: 'true'
+        push: 'true'
+        changelog-file: 'CHANGELOG.md'
+        version-file: 'VERSION'
+        update-version-in: 'pyproject.toml,version = "(.*)"'

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -2,7 +2,7 @@ name: Version
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   semver:
@@ -13,17 +13,17 @@ jobs:
       contents: write
     name: Update Version
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Print Environment Variables
-      run: |
-        env
-    - name: Run TinySemVer
-      uses: ./  # This uses the action defined in the current repository
-      with:
-        verbose: 'true'
-        push: 'true'
-        changelog-file: 'CHANGELOG.md'
-        version-file: 'VERSION'
-        update-version-in: 'pyproject.toml,version = "(.*)"'
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Print Environment Variables
+        run: |
+          env
+      - name: Run TinySemVer
+        uses: ./ # This uses the action defined in the current repository
+        with:
+          verbose: "true"
+          push: "true"
+          changelog-file: "CHANGELOG.md"
+          version-file: "VERSION"
+          update-version-in: 'pyproject.toml,version = "(.*)"'

--- a/README.md
+++ b/README.md
@@ -79,18 +79,18 @@ jobs:
     - name: Run TinySemVer
       uses: your-username/tinysemver@v1
       with:
-         dry-run: 'true'
-         verbose: 'true'
-         push: 'true'
-         major-verbs: 'breaking,break,major'
-         minor-verbs: 'feature,minor,add,new'
-         patch-verbs: 'fix,patch,bug,improve,docs'
-         changelog-file: 'CHANGELOG.md'
-         version-file: 'VERSION'
-         update-version-in: 'pyproject.toml,version = "(.*)"'
-         git-user-name: 'GitHub Actions'
-         git-user-email: 'actions@github.com'
-         github-token: ${{ secrets.GITHUB_TOKEN }}
+        dry-run: 'true'
+        verbose: 'true'
+        push: 'true'
+        major-verbs: 'breaking,break,major'
+        minor-verbs: 'feature,minor,add,new'
+        patch-verbs: 'fix,patch,bug,improve,docs'
+        changelog-file: 'CHANGELOG.md'
+        version-file: 'VERSION'
+        update-version-in: 'pyproject.toml,version = "(.*)"'
+        git-user-name: 'GitHub Actions'
+        git-user-email: 'actions@github.com'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Why?

--- a/README.md
+++ b/README.md
@@ -58,6 +58,41 @@ Alternatively, you can just ask for `--help`:
 $ tinysemver --help
 ```
 
+## Use the Action
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    # Add this condition to skip recursive releases
+    if: "!contains(github.event.head_commit.message, 'Release:')"
+    runs-on: ubuntu-latest
+
+    steps:
+    # Your existing steps...
+
+    - name: Run TinySemVer
+      uses: your-username/tinysemver@v1
+      with:
+         dry-run: 'true'
+         verbose: 'true'
+         push: 'true'
+         major-verbs: 'breaking,break,major'
+         minor-verbs: 'feature,minor,add,new'
+         patch-verbs: 'fix,patch,bug,improve,docs'
+         changelog-file: 'CHANGELOG.md'
+         version-file: 'VERSION'
+         update-version-in: 'pyproject.toml,version = "(.*)"'
+         git-user-name: 'GitHub Actions'
+         git-user-email: 'actions@github.com'
+         github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ## Why?
 
 In the past I was using [semantic-release](https://github.com/semantic-release/semantic-release) for my 10+ projects.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,88 @@
+name: 'TinySemVer'
+description: 'A tiny Python script that helps you manage your project''s versioning'
+inputs:
+  dry-run:
+    description: 'Do not create a new tag'
+    required: false
+    default: 'false'
+  verbose:
+    description: 'Print more information'
+    required: false
+    default: 'false'
+  push:
+    description: 'Push the new tag to the repository'
+    required: false
+    default: 'false'
+  major-verbs:
+    description: 'Comma-separated list of major verbs'
+    required: false
+  minor-verbs:
+    description: 'Comma-separated list of minor verbs'
+    required: false
+  patch-verbs:
+    description: 'Comma-separated list of patch verbs'
+    required: false
+  changelog-file:
+    description: 'Path to the changelog file'
+    required: false
+  version-file:
+    description: 'Path to the version file'
+    required: false
+  update-version-in:
+    description: 'Semicolon-separated list of file paths and regex patterns to update version'
+    required: false
+  update-major-version-in:
+    description: 'Semicolon-separated list of file paths and regex patterns to update major version'
+    required: false
+  update-minor-version-in:
+    description: 'Semicolon-separated list of file paths and regex patterns to update minor version'
+    required: false
+  update-patch-version-in:
+    description: 'Semicolon-separated list of file paths and regex patterns to update patch version'
+    required: false
+  default-branch:
+    description: 'Default branch to push the release commit to. Defaults to main'
+    required: false
+  git-user-name:
+    description: 'Git user name for commits'
+    required: false
+    default: 'TinySemVer'
+  git-user-email:
+    description: 'Git user email for commits'
+    required: false
+    default: 'tinysemver@ashvardanian.com'
+  github-token:
+    description: 'GitHub access token to push to protected branches'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    
+    - name: Run TinySemVer
+      shell: bash
+      env:
+        DRY_RUN: ${{ inputs.dry-run }}
+        VERBOSE: ${{ inputs.verbose }}
+        PUSH: ${{ inputs.push }}
+        MAJOR_VERBS: ${{ inputs.major-verbs }}
+        MINOR_VERBS: ${{ inputs.minor-verbs }}
+        PATCH_VERBS: ${{ inputs.patch-verbs }}
+        CHANGELOG_FILE: ${{ inputs.changelog-file }}
+        VERSION_FILE: ${{ inputs.version-file }}
+        UPDATE_VERSION_IN: ${{ inputs.update-version-in }}
+        UPDATE_MAJOR_VERSION_IN: ${{ inputs.update-major-version-in }}
+        UPDATE_MINOR_VERSION_IN: ${{ inputs.update-minor-version-in }}
+        UPDATE_PATCH_VERSION_IN: ${{ inputs.update-patch-version-in }}
+        REPO_PATH: ${{ github.workspace }}
+        GIT_USER_NAME: ${{ inputs.git-user-name }}
+        GIT_USER_EMAIL: ${{ inputs.git-user-email }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
+        DEFAULT_BRANCH: ${{ inputs.default-branch }}
+      run: |
+        cd $GITHUB_WORKSPACE
+        python ${{ github.action_path }}/tinysemver.py

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,8 @@ runs:
         TINYSEMVER_REPO_PATH: ${{ github.workspace }}
         TINYSEMVER_GIT_USER_NAME: ${{ inputs.git-user-name }}
         TINYSEMVER_GIT_USER_EMAIL: ${{ inputs.git-user-email }}
-        TINYSEMVER_GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
         TINYSEMVER_DEFAULT_BRANCH: ${{ inputs.default-branch }}
       run: |
         cd $GITHUB_WORKSPACE

--- a/action.yml
+++ b/action.yml
@@ -1,58 +1,58 @@
-name: 'TinySemVer'
-description: 'A tiny Python script that helps you manage your project''s versioning'
+name: "TinySemVer"
+description: "A tiny Python script that helps you manage your project's versioning"
 inputs:
   dry-run:
-    description: 'Do not create a new tag'
+    description: "Do not create a new tag"
     required: false
-    default: 'false'
+    default: "false"
   verbose:
-    description: 'Print more information'
+    description: "Print more information"
     required: false
-    default: 'false'
+    default: "false"
   push:
-    description: 'Push the new tag to the repository'
+    description: "Push the new tag to the repository"
     required: false
-    default: 'false'
+    default: "false"
   major-verbs:
-    description: 'Comma-separated list of major verbs'
+    description: "Comma-separated list of major verbs"
     required: false
   minor-verbs:
-    description: 'Comma-separated list of minor verbs'
+    description: "Comma-separated list of minor verbs"
     required: false
   patch-verbs:
-    description: 'Comma-separated list of patch verbs'
+    description: "Comma-separated list of patch verbs"
     required: false
   changelog-file:
-    description: 'Path to the changelog file'
+    description: "Path to the changelog file"
     required: false
   version-file:
-    description: 'Path to the version file'
+    description: "Path to the version file"
     required: false
   update-version-in:
-    description: 'Semicolon-separated list of file paths and regex patterns to update version'
+    description: "Semicolon-separated list of file paths and regex patterns to update version"
     required: false
   update-major-version-in:
-    description: 'Semicolon-separated list of file paths and regex patterns to update major version'
+    description: "Semicolon-separated list of file paths and regex patterns to update major version"
     required: false
   update-minor-version-in:
-    description: 'Semicolon-separated list of file paths and regex patterns to update minor version'
+    description: "Semicolon-separated list of file paths and regex patterns to update minor version"
     required: false
   update-patch-version-in:
-    description: 'Semicolon-separated list of file paths and regex patterns to update patch version'
+    description: "Semicolon-separated list of file paths and regex patterns to update patch version"
     required: false
   default-branch:
-    description: 'Default branch to push the release commit to. Defaults to main'
+    description: "Default branch to push the release commit to. Defaults to main"
     required: false
   git-user-name:
-    description: 'Git user name for commits'
+    description: "Git user name for commits"
     required: false
-    default: 'TinySemVer'
+    default: "TinySemVer"
   git-user-email:
-    description: 'Git user email for commits'
+    description: "Git user email for commits"
     required: false
-    default: 'tinysemver@ashvardanian.com'
+    default: "tinysemver@ashvardanian.com"
   github-token:
-    description: 'GitHub access token to push to protected branches'
+    description: "GitHub access token to push to protected branches"
     required: false
 
 runs:
@@ -61,28 +61,28 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
-    
+        python-version: "3.x"
+
     - name: Run TinySemVer
       shell: bash
       env:
-        DRY_RUN: ${{ inputs.dry-run }}
-        VERBOSE: ${{ inputs.verbose }}
-        PUSH: ${{ inputs.push }}
-        MAJOR_VERBS: ${{ inputs.major-verbs }}
-        MINOR_VERBS: ${{ inputs.minor-verbs }}
-        PATCH_VERBS: ${{ inputs.patch-verbs }}
-        CHANGELOG_FILE: ${{ inputs.changelog-file }}
-        VERSION_FILE: ${{ inputs.version-file }}
-        UPDATE_VERSION_IN: ${{ inputs.update-version-in }}
-        UPDATE_MAJOR_VERSION_IN: ${{ inputs.update-major-version-in }}
-        UPDATE_MINOR_VERSION_IN: ${{ inputs.update-minor-version-in }}
-        UPDATE_PATCH_VERSION_IN: ${{ inputs.update-patch-version-in }}
-        REPO_PATH: ${{ github.workspace }}
-        GIT_USER_NAME: ${{ inputs.git-user-name }}
-        GIT_USER_EMAIL: ${{ inputs.git-user-email }}
-        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
-        DEFAULT_BRANCH: ${{ inputs.default-branch }}
+        TINYSEMVER_DRY_RUN: ${{ inputs.dry-run }}
+        TINYSEMVER_VERBOSE: ${{ inputs.verbose }}
+        TINYSEMVER_PUSH: ${{ inputs.push }}
+        TINYSEMVER_MAJOR_VERBS: ${{ inputs.major-verbs }}
+        TINYSEMVER_MINOR_VERBS: ${{ inputs.minor-verbs }}
+        TINYSEMVER_PATCH_VERBS: ${{ inputs.patch-verbs }}
+        TINYSEMVER_CHANGELOG_FILE: ${{ inputs.changelog-file }}
+        TINYSEMVER_VERSION_FILE: ${{ inputs.version-file }}
+        TINYSEMVER_UPDATE_VERSION_IN: ${{ inputs.update-version-in }}
+        TINYSEMVER_UPDATE_MAJOR_VERSION_IN: ${{ inputs.update-major-version-in }}
+        TINYSEMVER_UPDATE_MINOR_VERSION_IN: ${{ inputs.update-minor-version-in }}
+        TINYSEMVER_UPDATE_PATCH_VERSION_IN: ${{ inputs.update-patch-version-in }}
+        TINYSEMVER_REPO_PATH: ${{ github.workspace }}
+        TINYSEMVER_GIT_USER_NAME: ${{ inputs.git-user-name }}
+        TINYSEMVER_GIT_USER_EMAIL: ${{ inputs.git-user-email }}
+        TINYSEMVER_GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
+        TINYSEMVER_DEFAULT_BRANCH: ${{ inputs.default-branch }}
       run: |
         cd $GITHUB_WORKSPACE
         python ${{ github.action_path }}/tinysemver.py

--- a/tinysemver.py
+++ b/tinysemver.py
@@ -118,9 +118,6 @@ def group_commits(
     patch_commits = []
 
     for commit in commits:
-        # Skip merge commits
-        if commit_starts_with_verb(commit, "merge"):
-            continue
         if any(commit_starts_with_verb(commit, verb) for verb in major_verbs):
             major_commits.append(commit)
         if any(commit_starts_with_verb(commit, verb) for verb in minor_verbs):

--- a/tinysemver.py
+++ b/tinysemver.py
@@ -485,24 +485,24 @@ def main():
         class Args:
             pass
         args = Args()
-        args.dry_run = os.environ.get('DRY_RUN', '').lower() == 'true'
-        args.verbose = os.environ.get('VERBOSE', '').lower() == 'true'
-        args.push = os.environ.get('PUSH', '').lower() == 'true'
-        args.major_verbs = os.environ.get('MAJOR_VERBS') or 'breaking,break,major'
-        args.minor_verbs = os.environ.get('MINOR_VERBS') or 'feature,minor,add,new'
-        args.patch_verbs = os.environ.get('PATCH_VERBS') or 'fix,patch,bug,improve,docs'
-        args.default_branch = os.environ.get('DEFAULT_BRANCH') or 'main'
-        args.changelog_file = os.environ.get('CHANGELOG_FILE')
-        args.version_file = os.environ.get('VERSION_FILE')
-        args.update_version_in = [tuple(item.split(',')) for item in os.environ.get('UPDATE_VERSION_IN', '').split(';') if item]
-        args.update_major_version_in = [tuple(item.split(',')) for item in os.environ.get('UPDATE_MAJOR_VERSION_IN', '').split(';') if item]
-        args.update_minor_version_in = [tuple(item.split(',')) for item in os.environ.get('UPDATE_MINOR_VERSION_IN', '').split(';') if item]
-        args.update_patch_version_in = [tuple(item.split(',')) for item in os.environ.get('UPDATE_PATCH_VERSION_IN', '').split(';') if item]
-        args.path = os.environ.get('REPO_PATH')
-        args.git_user_name = os.environ.get('GIT_USER_NAME', 'TinySemVer')
-        args.git_user_email = os.environ.get('GIT_USER_EMAIL', 'tinysemver@ashvardanian.com')
-        args.github_token = os.environ.get('GITHUB_TOKEN')
-        args.github_repository = os.environ.get('GITHUB_REPOSITORY')
+        args.dry_run = os.environ.get('TINYSEMVER_DRY_RUN', '').lower() == 'true'
+        args.verbose = os.environ.get('TINYSEMVER_VERBOSE', '').lower() == 'true'
+        args.push = os.environ.get('TINYSEMVER_PUSH', '').lower() == 'true'
+        args.major_verbs = os.environ.get('TINYSEMVER_MAJOR_VERBS') or 'breaking,break,major'
+        args.minor_verbs = os.environ.get('TINYSEMVER_MINOR_VERBS') or 'feature,minor,add,new'
+        args.patch_verbs = os.environ.get('TINYSEMVER_PATCH_VERBS') or 'fix,patch,bug,improve,docs'
+        args.default_branch = os.environ.get('TINYSEMVER_DEFAULT_BRANCH') or 'main'
+        args.changelog_file = os.environ.get('TINYSEMVER_CHANGELOG_FILE')
+        args.version_file = os.environ.get('TINYSEMVER_VERSION_FILE')
+        args.update_version_in = [tuple(item.split(',')) for item in os.environ.get('TINYSEMVER_UPDATE_VERSION_IN', '').split(';') if item]
+        args.update_major_version_in = [tuple(item.split(',')) for item in os.environ.get('TINYSEMVER_UPDATE_MAJOR_VERSION_IN', '').split(';') if item]
+        args.update_minor_version_in = [tuple(item.split(',')) for item in os.environ.get('TINYSEMVER_UPDATE_MINOR_VERSION_IN', '').split(';') if item]
+        args.update_patch_version_in = [tuple(item.split(',')) for item in os.environ.get('TINYSEMVER_UPDATE_PATCH_VERSION_IN', '').split(';') if item]
+        args.path = os.environ.get('TINYSEMVER_REPO_PATH')
+        args.git_user_name = os.environ.get('TINYSEMVER_GIT_USER_NAME', 'TinySemVer')
+        args.git_user_email = os.environ.get('TINYSEMVER_GIT_USER_EMAIL', 'tinysemver@ashvardanian.com')
+        args.github_token = os.environ.get('TINYSEMVER_GITHUB_TOKEN')
+        args.github_repository = os.environ.get('TINYSEMVER_GITHUB_REPOSITORY')
 
     try:
         bump(

--- a/tinysemver.py
+++ b/tinysemver.py
@@ -501,8 +501,8 @@ def main():
         args.path = os.environ.get('TINYSEMVER_REPO_PATH')
         args.git_user_name = os.environ.get('TINYSEMVER_GIT_USER_NAME', 'TinySemVer')
         args.git_user_email = os.environ.get('TINYSEMVER_GIT_USER_EMAIL', 'tinysemver@ashvardanian.com')
-        args.github_token = os.environ.get('TINYSEMVER_GITHUB_TOKEN')
-        args.github_repository = os.environ.get('TINYSEMVER_GITHUB_REPOSITORY')
+        args.github_token = os.environ.get('GITHUB_TOKEN')
+        args.github_repository = os.environ.get('GITHUB_REPOSITORY')
 
     try:
         bump(


### PR DESCRIPTION
Fixes #1 

Implements the GitHub Action. Testing on the side, on my fork: https://github.com/grouville/tinysemver

The idea is, to avoid the recursive call, there are two choices:
1. run the action nonetheless and handle the skip inside its logic
2. Have a more declarative model in which users can filter out, and use your pipeline as a reference

I tend more with the second one, as users can avoid wasting ressources with an additional step DX wise

## Changes

I added a `default-branch` param to the CLI. This is due to the fact that extracting the default branch of a repo inside a GitHub Job context is a bit tricky, spent a few hours trying to be smart today, with no luck. Instead of being falsely too smart, I prefer to make it declarative. It defaults to `main` when not set, but any repo with a default branch different from `main` shall set this key

Also, another design choice made is to directly push on main branch after the merge commit instead of opening a new PR and skip the merge commits from TinySemVer's logic. 

A bit of docs was added but could extend it

Proof of work: 
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/9b6be8b1-5e61-49a3-a5cb-651a87be1962">

P.S: Feel free to test on my fork, you should have write rights.

The recursive is being handled declaratively directly inside your action file, I like it better as it totally skips the job instead of being a silent skip. Users will have to copy it but it is not hard

