### PR TITLE
Feat: finalize the GitHub Action

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -28,4 +28,5 @@ jobs:
           changelog-file: "CHANGELOG.md"
           version-file: "VERSION"
           update-version-in: 'pyproject.toml,version = "(.*)"'
-          github_token: ${{ secrets.TINYSEMVER_TOKEN }}
+          github-token: ${{ secrets.TINYSEMVER_TOKEN }}
+          create-release: "true"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Print Environment Variables
         run: |
           env

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ jobs:
         git-user-name: 'GitHub Actions'
         git-user-email: 'actions@github.com'
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        create-release: 'true'
 ```
 
 ### Security Considerations for Protected Branches

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+     - uses: actions/checkout@v4
+        with:
+          persist-credentials: false # only if main branch if protected
     # Your existing steps...
 
     - name: Run TinySemVer
@@ -109,6 +112,27 @@ jobs:
         git-user-email: 'actions@github.com'
         github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+### Security Considerations for Protected Branches
+
+If your default branch is protected with a "pull request before merging" rule:
+
+1. A repository-scoped Personal Access Token (PAT) is required to push to the branch.
+2. Set `persist-credentials: false` in the `actions/checkout` step.
+
+⚠️ **Important Security Note:**
+- The default `GITHUB_TOKEN` cannot be used with protected branches.
+- Using a PAT instead of `GITHUB_TOKEN` poses security risks:
+  - Workflows from any branch can access secret variables.
+  - This could allow non-protected branches to use elevated permissions.
+- Mitigation:
+  - Use a fine-grained PAT with minimal necessary permissions.
+  - Prefer the `pull_request` workflow trigger, which limits permissions.
+  - Be cautious: users with write access could still potentially exploit workflows to expose the PAT.
+
+Always follow the principle of least privilege when setting up tokens and permissions.
+
+For more information on CI configurations and pushing changes in GitHub Actions, see the [semantic-release GitHub Actions guide](https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md#pushing-packagejson-changes-to-a-master-branch).
 
 ## Why?
 

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,10 @@ inputs:
   github-token:
     description: "GitHub access token to push to protected branches"
     required: false
-
+  create-release:
+    description: "Create a GitHub release using the GitHub CLI"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -84,6 +87,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         TINYSEMVER_DEFAULT_BRANCH: ${{ inputs.default-branch }}
+        TINYSEMVER_CREATE_RELEASE: ${{ inputs.create-release }}
       run: |
         cd $GITHUB_WORKSPACE
         python ${{ github.action_path }}/tinysemver.py

--- a/tinysemver.py
+++ b/tinysemver.py
@@ -185,13 +185,13 @@ def create_tag(
         #     raise RuntimeError("Failed to pull the latest changes from the remote repository")
 
         # Push both commits and the tag
-        push_result = subprocess.run(["git", "push", url, f"{new_commit_sha}:{default_branch}"], cwd=repository_path, env=env)
+        push_result = subprocess.run(["git", "push", url, f"{new_commit_sha}:{default_branch}"], cwd=repository_path, capture_output=True, env=env)
         if push_result.returncode != 0:
-            raise RuntimeError(f"Failed to push the new commits to the remote repository: '{url}'")
+            raise RuntimeError(f"Failed to push the new commits to the remote repository: '{url}' with error: {push_result.stderr}")
 
-        push_result = subprocess.run(["git", "push", url, "--tag"], cwd=repository_path, env=env)
+        push_result = subprocess.run(["git", "push", url, "--tag"], cwd=repository_path, capture_output=True, env=env)
         if push_result.returncode != 0:
-            raise RuntimeError(f"Failed to push the new tag to the remote repository: '{url}'")
+            raise RuntimeError(f"Failed to push the new tag to the remote repository: '{url}' with error: {push_result.stderr}")
         print(f"Pushed to: {url}")
 
 


### PR DESCRIPTION
## Enhance TinySemVer: GitHub Release Creation & Security Improvements

This PR addresses current errors and adds new features to TinySemVer.

### Key Changes

1. **Automatic GitHub Release Creation**
   - New 'create-release' flag using GitHub CLI to generate the release
   - Checks for CLI availability (especially for local runs)

2. **Improved Security**
   - Use `persist-credentials: false` for checkout action. Context is detailed in commit message / documentation
   - Added security considerations for PATs in README

3. **Enhanced Error Handling**
   - Extended error logging for better debugging

### Verification

Changes tested and working on fork: https://github.com/grouville/tinysemver

### Security Note

Current setup is secure, with pipelines running only on `main` and `releases`.

### Future Consideration

Potential enhancement of release notes generation.

@ashvardanian Please review, especially the release note process.